### PR TITLE
Add methods for logical input inversion.

### DIFF
--- a/examples/AnalogButtonToggleLedOnClick/AnalogButtonToggleLedOnClick.ino
+++ b/examples/AnalogButtonToggleLedOnClick/AnalogButtonToggleLedOnClick.ino
@@ -4,7 +4,9 @@
  * This sketch demonstrates using ObjectButton library with single analog button,
  * which will turn built-in LED on or off after being clicked.
  *
- * Copyright 2019-2020 JSC electronics
+ * ObjectButton library: https://github.com/JSC-electronics/ObjectButton
+ * 
+ * Copyright © JSC electronics
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/AnalogSensorToggleLedOnDetect/AnalogSensorToggleLedOnDetect.ino
+++ b/examples/AnalogSensorToggleLedOnDetect/AnalogSensorToggleLedOnDetect.ino
@@ -4,7 +4,9 @@
  * This sketch demonstrates using ObjectButton library with single analog sensor,
  * which will turn built-in LED on or off after some motion is being detected.
  *
- * Copyright 2019-2020 JSC electronics
+ * ObjectButton library: https://github.com/JSC-electronics/ObjectButton
+ * 
+ * Copyright © JSC electronics
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/BlinkMachine/BlinkMachine.ino
+++ b/examples/BlinkMachine/BlinkMachine.ino
@@ -11,7 +11,9 @@
  *
  * See their sketch for more details on internal workings, if it's not clear for your from this code.
  *
- * Copyright 2019-2020 JSC electronics
+ * ObjectButton library: https://github.com/JSC-electronics/ObjectButton
+ * 
+ * Copyright © JSC electronics
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/ClassNameConflictResolution/ClassNameConflictResolution.ino
+++ b/examples/ClassNameConflictResolution/ClassNameConflictResolution.ino
@@ -33,7 +33,9 @@
  * In this example, we'll show you, how to write your code, when you
  * have class name conflicts.
  * 
- * Copyright 2019-2020 JSC electronics
+ * ObjectButton library: https://github.com/JSC-electronics/ObjectButton
+ * 
+ * Copyright © JSC electronics
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/InvertInputLogic/InvertInputLogic.ino
+++ b/examples/InvertInputLogic/InvertInputLogic.ino
@@ -1,11 +1,17 @@
 /**
- * @brief Two distinct digital buttons example.
+ * @brief Invert input logic of two DigitalButtons. 
  *
- * This sketch demonstrates using ObjectButton library with two distinct digital buttons.
+ * This sketch demonstrates ObjectButton library with the option to invert input logic. 
+ * Logical 1 will be considered as logical 0 and vice versa.
+ * 
+ * By default, the user can invert the logic when creating an DigitalButton instance using 
+ * the second parameter in the constructor:
+ * - DigitalButton(INPUT_PIN, true) or
+ * - DigitalButton(INPUT_PIN, false) 
  *
- * In this example we receive all events produced by buttons and print
- * which event occurred on which button to the serial monitor.
- *
+ * In this example, however, the input logic can be also inverted during program execution.
+ * A long press of button 1 (INPUT_PIN_BUTTON1) inverts the logic of button 2 (INPUT_PIN_BUTTON2).
+ * 
  * ObjectButton library: https://github.com/JSC-electronics/ObjectButton
  * 
  * Copyright © JSC electronics
@@ -51,8 +57,8 @@ private:
 
     void onLongPressEnd(Button& button) override;
 
-    DigitalButton button1 = DigitalButton(INPUT_PIN_BUTTON1);
-    DigitalButton button2 = DigitalButton(INPUT_PIN_BUTTON2);
+    DigitalButton button1 = DigitalButton(INPUT_PIN_BUTTON1, true /* optional, logic inverted if true */);
+    DigitalButton button2 = DigitalButton(INPUT_PIN_BUTTON2, true /* optional, logic inverted if true */);
 };
 
 void TwoButtons::onClick(Button& button) {
@@ -103,6 +109,12 @@ void TwoButtons::onLongPressStart(Button& button) {
     switch (button.getId()) {
         case INPUT_PIN_BUTTON1:
             Serial.println("Long press started on button 1!");
+            button2.invertInputLogic();
+            if (button2.isInputLogicInverted()) {
+              Serial.println("Input logic is inverted.");
+            } else {
+              Serial.println("Input logic is NOT inverted.");
+            }
             break;
         case INPUT_PIN_BUTTON2:
             Serial.println("Long press started on button 2!");
@@ -128,15 +140,18 @@ void TwoButtons::init() {
     }
     Serial.println("Starting TwoButtons...");
 
-    button1.setDebounceTicks(10);
+    button1.setDebounceTicks(100);
     button1.setOnClickListener(this);
     button1.setOnDoubleClickListener(this);
     button1.setOnPressListener(this);
+    button1.setLongPressTicks(3000 /* ms */);
 
-    button2.setDebounceTicks(10);
+    button2.setDebounceTicks(100);
     button2.setOnClickListener(this);
     button2.setOnDoubleClickListener(this);
     button2.setOnPressListener(this);
+    button2.setLongPressTicks(3000 /* ms */);
+
 }
 
 void TwoButtons::update() {

--- a/examples/ToggleLedOnClick/ToggleLedOnClick.ino
+++ b/examples/ToggleLedOnClick/ToggleLedOnClick.ino
@@ -4,7 +4,9 @@
  * This sketch demonstrates using ObjectButton library with single digital button,
  * which will turn built-in LED on or off after being clicked.
  *
- * Copyright 2019-2020 JSC electronics
+ * ObjectButton library: https://github.com/JSC-electronics/ObjectButton
+ * 
+ * Copyright © JSC electronics
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/ToggleLedOnDoubleClick/ToggleLedOnDoubleClick.ino
+++ b/examples/ToggleLedOnDoubleClick/ToggleLedOnDoubleClick.ino
@@ -4,7 +4,9 @@
  * This sketch demonstrates using ObjectButton library with single digital button,
  * which will turn built-in LED on or off after being double-clicked.
  *
- * Copyright 2019-2020 JSC electronics
+ * ObjectButton library: https://github.com/JSC-electronics/ObjectButton
+ * 
+ * Copyright © JSC electronics
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/ToggleLedOnDoubleClickWithInterrupt/ToggleLedOnDoubleClickWithInterrupt.ino
+++ b/examples/ToggleLedOnDoubleClickWithInterrupt/ToggleLedOnDoubleClickWithInterrupt.ino
@@ -7,7 +7,9 @@
  * This example is almost identical to ToggleLedOnDoubleClick.ino, except
  * button state refresh is bound to interrupt.
  *
- * Copyright 2019-2020 JSC electronics
+ * ObjectButton library: https://github.com/JSC-electronics/ObjectButton
+ * 
+ * Copyright © JSC electronics
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/TurnLedOnLongPress/TurnLedOnLongPress.ino
+++ b/examples/TurnLedOnLongPress/TurnLedOnLongPress.ino
@@ -4,7 +4,9 @@
  * This sketch demonstrates using ObjectButton library with single digital button,
  * which will turn built-in LED on when it's long pressed.
  *
- * Copyright 2019-2020 JSC electronics
+ * ObjectButton library: https://github.com/JSC-electronics/ObjectButton
+ * 
+ * Copyright © JSC electronics
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/TwoAnalogButtonsOnTheSamePin/TwoAnalogButtonsOnTheSamePin.ino
+++ b/examples/TwoAnalogButtonsOnTheSamePin/TwoAnalogButtonsOnTheSamePin.ino
@@ -6,7 +6,9 @@
  * In this example we receive all events produced by buttons and print
  * which event occurred on which button to the serial monitor.
  *
- * Copyright 2019-2020 JSC electronics
+ * ObjectButton library: https://github.com/JSC-electronics/ObjectButton
+ * 
+ * Copyright © JSC electronics
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/TwoAnalogSensorsOnTheSamePin/TwoAnalogSensorsOnTheSamePin.ino
+++ b/examples/TwoAnalogSensorsOnTheSamePin/TwoAnalogSensorsOnTheSamePin.ino
@@ -5,7 +5,9 @@
  *
  * In this example we receive onClick() event, which simulates a motion detection.
  *
- * Copyright 2019-2020 JSC electronics
+ * ObjectButton library: https://github.com/JSC-electronics/ObjectButton
+ * 
+ * Copyright © JSC electronics
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/base/Button.cpp
+++ b/src/base/Button.cpp
@@ -136,7 +136,7 @@ void Button::setClickTicks(uint16_t ticks) {
  *
  * @param ticks a long press time interval in milliseconds.
  */
-void Button::setLongPressTicks(uint16_t ticks) {
+void Button::setLongPressTicks(uint16_t ticks /* ms */) {
     m_longPressTicks = ticks;
 }
 

--- a/src/digital/DigitalButton.cpp
+++ b/src/digital/DigitalButton.cpp
@@ -54,7 +54,7 @@ int DigitalButton::getId() {
  * Inverted logic means that if the input voltage level is high (e.g. 5 V DC), it will be treated as logic 0. 
  * Therefore, a low voltage level (0 V DC) will be represented as log 1.
  */
-void invertInputLogic() {
+void DigitalButton::invertInputLogic() {
     m_buttonPressed = LOW ? HIGH : LOW;    
 }
 
@@ -66,9 +66,9 @@ void invertInputLogic() {
  *
  * @return True if logic is inverted.
  */
-bool isInputLogicInverted() {
-    if ( m_buttonPressed = LOW ) return true;
-    else return false;
+bool DigitalButton::isInputLogicInverted() {
+    if ( m_buttonPressed = LOW ) {return true};
+    else {return false};
 }
 /**
  * @brief Evaluate wheter a button is pressed.

--- a/src/digital/DigitalButton.cpp
+++ b/src/digital/DigitalButton.cpp
@@ -48,6 +48,29 @@ int DigitalButton::getId() {
 }
 
 /**
+ * @brief Invert input logic.
+ * 
+ * This function allows the user to dynamically change the logic while the program is running.
+ * Inverted logic means that if the input voltage level is high (e.g. 5 V DC), it will be treated as logic 0. 
+ * Therefore, a low voltage level (0 V DC) will be represented as log 1.
+ */
+void invertInputLogic() {
+    m_buttonPressed = LOW ? HIGH : LOW;    
+}
+
+/**
+ * @brief Check if input logic is inverted.
+ *
+ * Inverted logic means that if the input voltage level is high (e.g. 5 V DC), it will be treated as logic 0. 
+ * Therefore, a low voltage level (0 V DC) will be represented as log 1.
+ *
+ * @return True if logic is inverted.
+ */
+bool isInputLogicInverted() {
+    if ( m_buttonPressed = LOW ) return true;
+    else return false;
+}
+/**
  * @brief Evaluate wheter a button is pressed.
  * 
  * This is a private method called from the state machine. It evaluates whether a button is pressed.

--- a/src/digital/DigitalButton.cpp
+++ b/src/digital/DigitalButton.cpp
@@ -67,8 +67,8 @@ void DigitalButton::invertInputLogic() {
  * @return True if logic is inverted.
  */
 bool DigitalButton::isInputLogicInverted() {
-    if ( m_buttonPressed = LOW ) {return true};
-    else {return false};
+    if ( m_buttonPressed = LOW ) {return true;}
+    else {return false;}
 }
 /**
  * @brief Evaluate wheter a button is pressed.

--- a/src/digital/DigitalButton.cpp
+++ b/src/digital/DigitalButton.cpp
@@ -55,7 +55,7 @@ int DigitalButton::getId() {
  * Therefore, a low voltage level (0 V DC) will be represented as log 1.
  */
 void DigitalButton::invertInputLogic() {
-    m_buttonPressed = LOW ? HIGH : LOW;    
+    m_buttonPressed = (m_buttonPressed == LOW) ? HIGH : LOW;
 }
 
 /**
@@ -67,8 +67,7 @@ void DigitalButton::invertInputLogic() {
  * @return True if logic is inverted.
  */
 bool DigitalButton::isInputLogicInverted() {
-    if ( m_buttonPressed = LOW ) {return true;}
-    else {return false;}
+    return (m_buttonPressed == LOW);
 }
 /**
  * @brief Evaluate wheter a button is pressed.
@@ -76,5 +75,5 @@ bool DigitalButton::isInputLogicInverted() {
  * This is a private method called from the state machine. It evaluates whether a button is pressed.
  */
 bool DigitalButton::isButtonPressed() {
-    return digitalRead(m_pin) == m_buttonPressed;
+    return (digitalRead(m_pin) == m_buttonPressed);
 }

--- a/src/digital/DigitalButton.h
+++ b/src/digital/DigitalButton.h
@@ -34,6 +34,10 @@ namespace jsc {
 
         int getId() override;
 
+        bool isInputLogicInverted();
+
+        void invertInputLogic();
+
     private:
         bool isButtonPressed() override;
 


### PR DESCRIPTION
This SW modification allows user to dynamically change input logic of DigitalButton instance. 

An input for which a high voltage level (e.g. 5 V DC) was considered a logic 1 may be considered a logic 0 and vice versa. In the original version of the code it was only possible to affect this when creating an instance of the DigitalButton class.


